### PR TITLE
change of payload values for inputs

### DIFF
--- a/binary_sensors/garden_pro4.yaml
+++ b/binary_sensors/garden_pro4.yaml
@@ -2,32 +2,32 @@
   name: "Garden Pro4 Input 0"
   unique_id: binary_sensor.garden_pro4_input_0
   value_template: "{{ value_json.state }}"
-  payload_on: "true"
-  payload_off: "false"
+  payload_on: "True"
+  payload_off: "False"
   state_topic: shellies/garden-pro4/status/input:0
 
 - platform: mqtt
   name: "Garden Pro4 Input 1"
   unique_id: binary_sensor.garden_pro4_input_1
   value_template: "{{ value_json.state }}"
-  payload_on: "true"
-  payload_off: "false"
+  payload_on: "True"
+  payload_off: "False"
   state_topic: shellies/garden-pro4/status/input:1
 
 - platform: mqtt
   name: "Garden Pro4 Input 2"
   unique_id: binary_sensor.garden_pro4_input_2
   value_template: "{{ value_json.state }}"
-  payload_on: "true"
-  payload_off: "false"
+  payload_on: "True"
+  payload_off: "False"
   state_topic: shellies/garden-pro4/status/input:2
 
 - platform: mqtt
   name: "Garden Pro4 Input 3"
   unique_id: binary_sensor.garden_pro4_input_3
   value_template: "{{ value_json.state }}"
-  payload_on: "true"
-  payload_off: "false"
+  payload_on: "True"
+  payload_off: "False"
   state_topic: shellies/garden-pro4/status/input:3
 
 - platform: mqtt  

--- a/binary_sensors/wardrobe_lamp.yaml
+++ b/binary_sensors/wardrobe_lamp.yaml
@@ -2,8 +2,8 @@
   name: "Wardrobe Lamp Input"
   unique_id: binary_sensor.wardrobe_lamp_input
   value_template: "{{ value_json.state }}"
-  payload_on: "true"
-  payload_off: "false"
+  payload_on: "True"
+  payload_off: "False"
   state_topic: shellies/wardrobe-lamp/status/input:0
 
 - platform: mqtt  


### PR DESCRIPTION
As value from shelly isn't string but boolean, home assistant will make first letter capital and then cast it to string. Tested with `shelly plus 1` on Home Assistant 2021.12.7